### PR TITLE
Allow optional email parameter to /subscribe.

### DIFF
--- a/api.md
+++ b/api.md
@@ -13,6 +13,7 @@ This endpoint reserves a new name for the gateway as a subdomain managed by the 
 *Parameters:*
 * `name`: the requested name to use as part of the subdomain assigned to the gateway.
 * `desc`: optional, a friendly description of this gateway. If this parameter is not present, a default description is generated including the gateway's name.
+* `email`: optional, used to determine if an existing domain is associated with the provided email or not.
 * `reclamationToken`: optional, the reclamation token assigned to this domain.
 
 *Returns:*

--- a/server/src/routes.rs
+++ b/server/src/routes.rs
@@ -314,6 +314,19 @@ fn subscribe(req: &mut Request, config: &Config) -> IronResult<Response> {
                         }
                         _ => {
                             // We already have a record for this name, return an error.
+                            let email = map.find(&["email"]);
+                            if !email.is_none() {
+                                let email = String::from_value(email.unwrap()).unwrap();
+                                if email == record.email.unwrap() {
+                                    let mut response = Response::with(
+                                        r#"{"error": "UnavailableNameReclamationPossible"}"#,
+                                    );
+                                    response.status = Some(status::BadRequest);
+                                    response.headers.set(ContentType::json());
+                                    return Ok(response);
+                                }
+                            }
+
                             let mut response = Response::with(r#"{"error": "UnavailableName"}"#);
                             response.status = Some(status::BadRequest);
                             response.headers.set(ContentType::json());


### PR DESCRIPTION
This can be used to determine if domain reclamation is possible, in the event that the requested domain is already in use.